### PR TITLE
Potential fix for code scanning alert no. 7: Use of externally-controlled format string

### DIFF
--- a/src/lib/bot/positionManager.ts
+++ b/src/lib/bot/positionManager.ts
@@ -2078,7 +2078,7 @@ export class PositionManager extends EventEmitter implements PositionTracker {
       // Always adjust orders when position size changes
       await this.adjustProtectiveOrders(position, slOrder, tpOrder);
     } catch (error: any) {
-      console.error(`PositionManager: Error checking orders for position ${positionKey}:`, error?.response?.data || error?.message);
+      console.error('PositionManager: Error checking orders for position %s:', positionKey, error?.response?.data || error?.message);
       // Log to error database
       errorLogger.logError(error instanceof Error ? error : new Error(String(error)), {
         type: 'general',


### PR DESCRIPTION
Potential fix for [https://github.com/CryptoGnome/aster_lick_hunter_node/security/code-scanning/7](https://github.com/CryptoGnome/aster_lick_hunter_node/security/code-scanning/7)

To resolve this problem, any user-supplied data (in this case, `positionKey`) should not be interpolated into the *format* string (the first argument) if additional arguments are passed to logging functions in Node.js. Instead, the best practice is to use a static format string with a format specifier (such as `%s`) for the user-supplied variable, and pass the untrusted data as a separate argument. For maximum safety and readability, always prefer passing user data as separate arguments, letting the logging function handle insertion, rather than interpolating it into the format string.

Specifically, in `src/lib/bot/positionManager.ts`, line 2081, change:
```js
console.error(`PositionManager: Error checking orders for position ${positionKey}:`, error?.response?.data || error?.message);
```
to:
```js
console.error('PositionManager: Error checking orders for position %s:', positionKey, error?.response?.data || error?.message);
```
This ensures that no possible format specifier in `positionKey` will be interpreted, as it will be safely inserted as a string.

No additional imports or methods are needed, as this is standard use of `console.error` in Node.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
