### PR TITLE
fix: resolve order PnL display issues with simultaneous closes (#39)

### DIFF
--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -1,5 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { ApiCredentials, Order } from '../types';
+import { Trade } from '../types/order';
 import { buildSignedForm, buildSignedQuery } from './auth';
 import { getRateLimitedAxios } from './requestInterceptor';
 import { symbolPrecision } from '../utils/symbolPrecision';
@@ -222,6 +223,41 @@ export async function getPositions(credentials: ApiCredentials): Promise<any[]> 
       'X-MBX-APIKEY': credentials.apiKey
     }
   });
+  return response.data;
+}
+
+// Get user trades for a specific symbol
+export async function getUserTrades(
+  symbol: string,
+  credentials: ApiCredentials,
+  params?: {
+    startTime?: number;
+    endTime?: number;
+    fromId?: number;
+    limit?: number;
+  }
+): Promise<Trade[]> {
+  const queryParams: Record<string, any> = {
+    symbol,
+    limit: params?.limit || 500,
+  };
+
+  if (params?.startTime) queryParams.startTime = params.startTime;
+  if (params?.endTime) queryParams.endTime = params.endTime;
+  if (params?.fromId) queryParams.fromId = params.fromId;
+
+  const query = buildSignedQuery(queryParams, credentials);
+
+  const axios = getRateLimitedAxios();
+  const response: AxiosResponse<Trade[]> = await axios.get(
+    `${BASE_URL}/fapi/v1/userTrades?${query}`,
+    {
+      headers: {
+        'X-MBX-APIKEY': credentials.apiKey
+      }
+    }
+  );
+
   return response.data;
 }
 

--- a/src/lib/types/order.ts
+++ b/src/lib/types/order.ts
@@ -132,3 +132,20 @@ export interface OrderUpdate {
     realizedProfit: string;
   };
 }
+
+export interface Trade {
+  buyer: boolean;
+  commission: string;
+  commissionAsset: string;
+  id: number;
+  maker: boolean;
+  orderId: number;
+  price: string;
+  qty: string;
+  quoteQty: string;
+  realizedPnl: string;
+  side: OrderSide;
+  positionSide: PositionSide;
+  symbol: string;
+  time: number;
+}


### PR DESCRIPTION
## Summary
Fixes #39 - Recent orders table now correctly displays all trade data, including PnL for multiple simultaneous order closes.

## Problem
- When multiple orders closed at the same time (e.g., TP order + entry order), only one PnL value was displayed
- The other order showed incorrect or missing PnL data ($0.20 instead of $1.21)
- Orders for symbols beyond the first 5 configured were not fetched

## Root Cause Analysis

### Issue 1: Time Window Collision
The original implementation used income history with a 5-second time window to match PnL to orders:
```typescript
const timeWindow = Math.floor(order.updateTime / 5000) * 5000;
const key = `${order.symbol}_${timeWindow}`;
pnlMap.set(key, record.income); // ❌ Overwrites previous value!
```

When multiple orders closed simultaneously, they mapped to the same key, causing the Map to overwrite previous PnL values. Only the last entry survived.

### Issue 2: Symbol Fetch Limit
The code limited fetching to only the first 5 configured symbols, causing orders for additional symbols to not appear.

## Solution

### Use `/fapi/v1/userTrades` API Endpoint
Replaced the time-window based income history matching with direct trade data from the user trades endpoint:
- Returns exact `realizedPnl` per trade
- Direct mapping via `orderId` - no time window collision
- More reliable and accurate than income history aggregation

### Implementation Details
1. **Created `getUserTrades()` function** in `src/lib/api/orders.ts`
   - Fetches trade history for symbols
   - Returns Trade objects with realizedPnl field

2. **Added `Trade` interface** in `src/lib/types/order.ts`
   - Properly typed according to Aster Finance API docs

3. **Updated order fetching logic** in `src/app/api/orders/all/route.ts`
   - Replaced income history with user trades
   - Uses `orderId` for precise matching
   - Aggregates PnL for orders with multiple fills
   - Removed 5-symbol limit

## Changes
- ✅ `src/lib/types/order.ts`: Add Trade interface
- ✅ `src/lib/api/orders.ts`: Add getUserTrades() API function  
- ✅ `src/app/api/orders/all/route.ts`: Replace income history with user trades logic

## Expected Outcome
- ✅ All closed orders display correct realized PnL from historical data
- ✅ Multiple simultaneous closes each show their own correct PnL values
- ✅ Data persists across page refreshes
- ✅ Quantity displayed matches actual trade quantity
- ✅ All configured symbols show complete order history

## Testing
- [x] TypeScript compilation passes with no errors
- [ ] Manual testing: Close multiple positions simultaneously
- [ ] Verify both orders show correct individual PnL values
- [ ] Refresh page and confirm PnL data persists

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)