### PR TITLE
fix: correct optimizer metrics display in BeforeAfterComparison

### DIFF
--- a/src/components/optimizer/BeforeAfterComparison.tsx
+++ b/src/components/optimizer/BeforeAfterComparison.tsx
@@ -61,14 +61,20 @@ export function BeforeAfterComparison({ results }: BeforeAfterComparisonProps) {
       const current = rec.performance?.current || {};
       const optimized = rec.performance?.optimized || {};
 
+      // Performance data has separate long/short metrics, we need to combine them
+      const currentLong = current.long || {};
+      const currentShort = current.short || {};
+      const optimizedLong = optimized.long || {};
+      const optimizedShort = optimized.short || {};
+
       return {
-        currentSharpe: acc.currentSharpe + (current.sharpeRatio || 0),
-        optimizedSharpe: acc.optimizedSharpe + (optimized.sharpeRatio || 0),
-        currentDrawdown: Math.max(acc.currentDrawdown, current.maxDrawdown || 0),
-        optimizedDrawdown: Math.max(acc.optimizedDrawdown, optimized.maxDrawdown || 0),
-        currentWinRate: acc.currentWinRate + (current.winRate || 0),
-        optimizedWinRate: acc.optimizedWinRate + (optimized.winRate || 0),
-        count: acc.count + 1,
+        currentSharpe: acc.currentSharpe + (currentLong.sharpe || 0) + (currentShort.sharpe || 0),
+        optimizedSharpe: acc.optimizedSharpe + (optimizedLong.sharpe || 0) + (optimizedShort.sharpe || 0),
+        currentDrawdown: Math.max(acc.currentDrawdown, currentLong.maxDrawdown || 0, currentShort.maxDrawdown || 0),
+        optimizedDrawdown: Math.max(acc.optimizedDrawdown, optimizedLong.maxDrawdown || 0, optimizedShort.maxDrawdown || 0),
+        currentWinRate: acc.currentWinRate + (currentLong.winRate || 0) + (currentShort.winRate || 0),
+        optimizedWinRate: acc.optimizedWinRate + (optimizedLong.winRate || 0) + (optimizedShort.winRate || 0),
+        count: acc.count + 2, // Count both long and short
       };
     },
     {


### PR DESCRIPTION
## Summary
Fixed issue where optimizer results showed 0.00 for Sharpe Ratio, Max Drawdown, and Win Rate in the "After" section.

## Problem
The `BeforeAfterComparison` component was accessing performance metrics at the wrong level in the data structure. It was looking for `rec.performance.current.sharpeRatio` directly, but the actual structure has separate long/short data at `rec.performance.current.long.sharpe` and `rec.performance.current.short.sharpe`.

## Solution
- Updated `BeforeAfterComparison.tsx` to correctly access nested long/short performance data
- Now properly aggregates metrics from both long and short sides:
  - Sums Sharpe Ratio from both long and short
  - Takes max of drawdowns across both sides
  - Properly averages win rates from both positions
- Adjusted count to account for both long and short entries

## Testing
After this fix, the optimizer results page will display the actual optimized metrics instead of zeros.

## Files Changed
- `src/components/optimizer/BeforeAfterComparison.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)